### PR TITLE
Add support for native TestCafe video recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ for example:
 * selenium:chrome@52.0:linux
 
 ### Customize Capabilities
-The capabilities of browsers can be further customize via configuration file (default is capabilities.json).
+The capabilities of browsers can be further customized via configuration file (default is capabilities.json).
 
 for example:
 ```json
@@ -60,6 +60,24 @@ for example:
         }
     }
 }
+```
+
+### Enable Video Recording
+This provider supports the native TestCafe video recording functionality (--video) with a small tweak. For this to work properly, you must add `@ffmpeg-installer/ffmpeg` to both your project and your docker image and install its' dependencies.
+
+for example:
+```bash
+FROM node:latest AS node_base
+
+RUN npm install -g @ffmpeg-installer/ffmpeg
+
+FROM selenium/standalone-chrome
+
+USER root
+
+COPY --from=node_base . .
+
+RUN cd /usr/local/lib/node_modules/@ffmpeg-installer/ffmpeg && npm install # This is important
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ for example:
 ```
 
 ### Enable Video Recording
-This provider supports the native TestCafe video recording functionality (--video) with a small tweak. For this to work properly, you must add `@ffmpeg-installer/ffmpeg` to both your project and your docker image and install its' dependencies.
+This provider supports the native TestCafe video recording functionality ([--video](https://devexpress.github.io/testcafe/documentation/reference/command-line-interface.html#--video-basepath)) with a small tweak. For this to work properly, you must add `@ffmpeg-installer/ffmpeg` to both your project and your docker image and install its' dependencies.
 
 for example:
 ```bash

--- a/README.md
+++ b/README.md
@@ -62,24 +62,6 @@ for example:
 }
 ```
 
-### Enable Video Recording
-This provider supports the native TestCafe video recording functionality ([--video](https://devexpress.github.io/testcafe/documentation/reference/command-line-interface.html#--video-basepath)) with a small tweak. For this to work properly, you must add `@ffmpeg-installer/ffmpeg` to both your project and your docker image and install its' dependencies.
-
-for example:
-```bash
-FROM node:latest AS node_base
-
-RUN npm install -g @ffmpeg-installer/ffmpeg
-
-FROM selenium/standalone-chrome
-
-USER root
-
-COPY --from=node_base . .
-
-RUN cd /usr/local/lib/node_modules/@ffmpeg-installer/ffmpeg && npm install # This is important
-```
-
 ## Configuration
 
 Use the following optional environment variable to set additional configuration options:

--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,12 @@ export default {
         writeFileSync(screenshotPath, screenshot, 'base64');
     },
 
+    async getVideoFrameData (id) {
+        const screenshot = await this.openedBrowsers[id].takeScreenshot();
+
+        return await Buffer.from(screenshot, 'base64');
+    },
+
     async isLocalBrowser () {
         return false;
     }


### PR DESCRIPTION
Problem:
This provider does not support any video recording as mentioned in https://github.com/alexschwantes/testcafe-browser-provider-selenium/issues/11 and  https://github.com/DevExpress/testcafe/issues/5062.

Solution:
Implement the `getVideoFrameData` from the TestCafe documentation https://github.com/DevExpress/testcafe/issues/5062#issuecomment-634783651 to allow their native video recording, in addition to updating docs telling users to install `@ffmpeg-installer/ffmpeg` on top of the `selenium/standalone-chrome` image.