### PR TITLE
feat: add webdriver proxy environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Use the following optional environment variable to set additional configuration 
 * `SELENIUM_CAPABILITIES` - (optional) Path to capabilities file. Default is capabilities.json.
 * `SELENIUM_MAX_TRIES` - (optional) Max tries of opening browser. Default is 1.
 * `SELENIUM_RETRY_INTERVAL` - (optional) Interval between retries of opening browser. Default is 5,000 milliseconds.
+* `SELENIUM_PROXY` - (optional) Sets the URL of the proxy to use for the WebDriver's HTTP connections.
 
 ## Author
 Alex Schwantes

--- a/src/index.js
+++ b/src/index.js
@@ -56,9 +56,7 @@ export default {
         const browser = _findMatch(browserProfile, /([^#]+)/);
         const version = _findMatch(browserName, /@([^:]+)/);
         const platform = _findMatch(browserName, /:(.+)/);
-
-        let proxy = process.env.SELENIUM_PROXY || "";
-
+        const proxy = process.env.SELENIUM_PROXY || '';
         const builder = new Builder().usingWebDriverProxy(proxy).forBrowser(_formalName(browser), version, platform).usingServer(this.seleniumServer);
         const browserOptions = createBrowserOptions[browser];
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,9 @@ export default {
         const version = _findMatch(browserName, /@([^:]+)/);
         const platform = _findMatch(browserName, /:(.+)/);
 
-        const builder = new Builder().forBrowser(_formalName(browser), version, platform).usingServer(this.seleniumServer);
+        let proxy = process.env.SELENIUM_PROXY || "";
+
+        const builder = new Builder().usingWebDriverProxy(proxy).forBrowser(_formalName(browser), version, platform).usingServer(this.seleniumServer);
         const browserOptions = createBrowserOptions[browser];
 
         if (browserOptions && existsSync(this.capabilities)) {


### PR DESCRIPTION
Add selenium usingWebDriverProxy option. This is useful when selenium is hosted in the cloud, for instance AWS. 

This should take care of this issue. #21 