### PR TITLE
Reliable Screenshots (resizeWindow and SELENIUM_RESIZE_OFFSET_HEIGHT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,5 @@ Use the following optional environment variable to set additional configuration 
 
 If you experience problems, where [`t.takeScreenshot`](https://testcafe.io/documentation/402675/reference/test-api/testcontroller/takescreenshot) produces screenshots, that dont have exactly the height as set using `t.resizeWindow` you might want to check the `SELENIUM_RESIZE_OFFSET_HEIGHT` enviornment variable.
 
-### Resize
-
-[`t.resizeWindow`](https://testcafe.io/documentation/402691/reference/test-api/testcontroller/resizewindow) used to directly use Seleniums [`Window.setRect()`](https://www.selenium.dev/documentation/webdriver/interactions/windows/#set-window-size) method, which worked fine for headless mode, but not when used in windowed mode.
-This should be fixed now.
-
 ## Author
 Alex Schwantes

--- a/README.md
+++ b/README.md
@@ -141,6 +141,13 @@ Use the following optional environment variable to set additional configuration 
 * `SELENIUM_MAX_TRIES` - (optional) Max tries of opening browser. Default is 1.
 * `SELENIUM_RETRY_INTERVAL` - (optional) Interval between retries of opening browser. Default is 5,000 milliseconds.
 * `SELENIUM_PROXY` - (optional) Sets the URL of the proxy to use for the WebDriver's HTTP connections.
+* `SELENIUM_RESIZE_OFFSET_HEIGHT` - (optional) add this offset to the height of the screen when resizing the window.
+
+## Notes
+
+### Screenshots
+
+If you experience problems, where [`t.takeScreenshot`](https://testcafe.io/documentation/402675/reference/test-api/testcontroller/takescreenshot) produces screenshots, that dont have exactly the height as set using `t.resizeWindow` you might want to check the `SELENIUM_RESIZE_OFFSET_HEIGHT` enviornment variable.
 
 ## Author
 Alex Schwantes

--- a/README.md
+++ b/README.md
@@ -149,5 +149,10 @@ Use the following optional environment variable to set additional configuration 
 
 If you experience problems, where [`t.takeScreenshot`](https://testcafe.io/documentation/402675/reference/test-api/testcontroller/takescreenshot) produces screenshots, that dont have exactly the height as set using `t.resizeWindow` you might want to check the `SELENIUM_RESIZE_OFFSET_HEIGHT` enviornment variable.
 
+### Resize
+
+[`t.resizeWindow`](https://testcafe.io/documentation/402691/reference/test-api/testcontroller/resizewindow) used to directly use Seleniums [`Window.setRect()`](https://www.selenium.dev/documentation/webdriver/interactions/windows/#set-window-size) method, which worked fine for headless mode, but not when used in windowed mode.
+This should be fixed now.
+
 ## Author
 Alex Schwantes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-browser-provider-selenium",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Selenium TestCafe browser provider plugin.",
   "repository": "https://github.com/alexschwantes/testcafe-browser-provider-selenium",
   "homepage": "https://github.com/alexschwantes/testcafe-browser-provider-selenium",

--- a/src/index.js
+++ b/src/index.js
@@ -170,7 +170,7 @@ export default {
         const driver = this.openedBrowsers[id];
         
         // implementation based on
-        // https://github.com/DevExpress/testcafe-browser-tools/blob/master/src/api/screenshot.js
+        // https://github.com/DevExpress/testcafe-browser-tools/blob/master/src/api/resize.js
 
         const currentClientAreaSize = { width: currentWidth, height: currentHeight };
 

--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,10 @@ export default {
     },
 
     async resizeWindow (id, width, height, currentWidth, currentHeight) {
+        const resizeOffsetHeight = Number(process.env.SELENIUM_RESIZE_OFFSET_HEIGHT ?? 0);
+        
+        height += resizeOffsetHeight;
+
         /** @type {import("selenium-webdriver").WebDriver} */
         const driver = this.openedBrowsers[id];
         

--- a/src/index.js
+++ b/src/index.js
@@ -161,9 +161,30 @@ export default {
         return true;
     },
 
-    async resizeWindow (id, width, height /*, currentWidth, currentHeight*/) {
-        // this sets the browser size, not the size of the visible screen so output may vary. setSize doesn't appear to be a function of webdriverjs
-        await this.openedBrowsers[id].manage().window().setRect({ width: width, height: height });
+    async resizeWindow (id, width, height, currentWidth, currentHeight) {
+        /** @type {import("selenium-webdriver").WebDriver} */
+        const driver = this.openedBrowsers[id];
+        
+        // implementation based on
+        // https://github.com/DevExpress/testcafe-browser-tools/blob/master/src/api/screenshot.js
+
+        const currentClientAreaSize = { width: currentWidth, height: currentHeight };
+
+        const currentWindowSize = await driver.manage().window().getRect();
+        
+        const requestedSize = { width, height };
+        
+        const chrome = {
+            width:  currentWindowSize.width - currentClientAreaSize.width,
+            height: currentWindowSize.height - currentClientAreaSize.height,
+        };
+
+        const correctedSize = {
+            width:  requestedSize.width + chrome.width,
+            height: requestedSize.height + chrome.height,
+        };
+
+        await driver.manage().window().setRect(correctedSize);
     },
 
     async maximizeWindow (id) {


### PR DESCRIPTION
Hi,

screenshots are unreliable, because resizeWindow is unreliable.

[`t.resizeWindow`](https://testcafe.io/documentation/402691/reference/test-api/testcontroller/resizewindow) directly uses Seleniums [`Window.setRect()`](https://www.selenium.dev/documentation/webdriver/interactions/windows/#set-window-size) method, which worked fine for headless mode, but not when used in windowed mode.

This should be fixed now.

But somehow the screenshots I took were 1px smaller than the size set using resizeWindow.
To workaround this, I added SELENIUM_RESIZE_OFFSET_HEIGHT which allows me to set this offset for selenium instead of inside my test code.

I hope you like what I did, and am looking forward to your feedback, which I am happy to apply to my PR.